### PR TITLE
UTC timestamps for carriers

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cheerio": "~0.13.1",
     "grunt": "~0.4.2",
     "grunt-contrib-coffee": "~0.10.0",
-    "moment": "~2.5.1",
+    "moment-timzeone": "~0.4.0",
     "request": "~2.33.0",
     "underscore": "~1.5.2",
     "xml2js": "~0.4.1"

--- a/src/a1.coffee
+++ b/src/a1.coffee
@@ -68,7 +68,7 @@ class A1Client extends ShipperClient
     activities = shipment['TrackingEventHistory']?[0]?['TrackingEventDetail'] or []
     [..., firstActivity] = activities
     return unless firstActivity?['EstimatedDeliveryDate']?[0]?
-    moment(firstActivity?['EstimatedDeliveryDate']?[0]).toDate()
+    moment("#{firstActivity?['EstimatedDeliveryDate']?[0]}T00:00:00Z").toDate()
 
   getService: (shipment) ->
     null

--- a/src/a1.coffee
+++ b/src/a1.coffee
@@ -1,5 +1,5 @@
 {Parser} = require 'xml2js'
-moment = require 'moment'
+moment = require 'moment-timezone'
 {titleCase} = require 'change-case'
 {ShipperClient} = require './shipper'
 

--- a/src/amazon.coffee
+++ b/src/amazon.coffee
@@ -31,7 +31,7 @@ class AmazonClient extends ShipperClient
     $(summary).children('span').each (sindex, span) ->
       if /Expected delivery/.test $(span).text()
         etaString = $(span).next().text().split(',')[1..-1].join(',')
-        eta = moment(etaString, ' MMM D, YYYY by h:mma').toDate()
+        eta = moment("#{etaString} +0000", ' MMM D, YYYY by h:mma Z').toDate()
     eta
 
   presentStatus: (details) ->

--- a/src/amazon.coffee
+++ b/src/amazon.coffee
@@ -1,5 +1,5 @@
 {load} = require 'cheerio'
-moment = require 'moment'
+moment = require 'moment-timezone'
 request = require 'request'
 {titleCase, upperCaseFirst, lowerCase} = require 'change-case'
 {ShipperClient} = require './shipper'

--- a/src/dhl.coffee
+++ b/src/dhl.coffee
@@ -1,5 +1,5 @@
 {Builder, Parser} = require 'xml2js'
-moment = require 'moment'
+moment = require 'moment-timezone'
 {titleCase, upperCaseFirst, lowerCase} = require 'change-case'
 {ShipperClient} = require './shipper'
 

--- a/src/dhl.coffee
+++ b/src/dhl.coffee
@@ -46,9 +46,9 @@ class DhlClient extends ShipperClient
 
   presentTimestamp: (dateString, timeString) ->
     return unless dateString?
-    formatSpec = if timeString? then 'YYYY-MM-DD HH:mm' else 'YYYY-MM-DD'
-    inputString = if timeString? then "#{dateString} #{timeString}" else dateString
-    moment(inputString, formatSpec).toDate()
+    timeString ?= '00:00'
+    inputString = "#{dateString} #{timeString} +0000"
+    moment(inputString).toDate()
 
   presentAddress: (rawAddress) ->
     return unless rawAddress?

--- a/src/fedex.coffee
+++ b/src/fedex.coffee
@@ -1,6 +1,6 @@
 {Builder, Parser} = require 'xml2js'
 {find} = require 'underscore'
-moment = require 'moment'
+moment = require 'moment-timezone'
 {titleCase} = require 'change-case'
 {ShipperClient} = require './shipper'
 

--- a/src/guessCarrier.coffee
+++ b/src/guessCarrier.coffee
@@ -100,6 +100,7 @@ CARRIERS = [
   {name: 'usps', regex: /^420\d{31}$/, confirm: _confirmUsps420ZipPlus4}
   {name: 'usps', regex: /^[A-Z]{2}\d{9}[A-Z]{2}$/}
   {name: 'lasership', regex: /^L[A-Z]\d{8}$/}
+  {name: 'lasership', regex: /^1LS\d{17}$/}
   {name: 'ontrac', regex: /^(C|D)\d{14}$/}
 ]
 

--- a/src/lasership.coffee
+++ b/src/lasership.coffee
@@ -25,7 +25,9 @@ class LasershipClient extends ShipperClient
     'Delivered': ShipperClient.STATUS_TYPES.DELIVERED
     'OutForDelivery': ShipperClient.STATUS_TYPES.OUT_FOR_DELIVERY
     'Arrived': ShipperClient.STATUS_TYPES.EN_ROUTE
+    'Received': ShipperClient.STATUS_TYPES.EN_ROUTE
     'OrderReceived': ShipperClient.STATUS_TYPES.SHIPPING
+    'OrderCreated': ShipperClient.STATUS_TYPES.SHIPPING
 
   presentStatus: (eventType) ->
     STATUS_MAP[eventType] if eventType?

--- a/src/lasership.coffee
+++ b/src/lasership.coffee
@@ -1,5 +1,5 @@
 {find} = require 'underscore'
-moment = require 'moment'
+moment = require 'moment-timezone'
 {titleCase} = require 'change-case'
 {ShipperClient} = require './shipper'
 

--- a/src/lasership.coffee
+++ b/src/lasership.coffee
@@ -37,7 +37,7 @@ class LasershipClient extends ShipperClient
     for rawActivity in rawActivities or []
       location = @presentAddress rawActivity
       dateTime = rawActivity?['DateTime']
-      timestamp = moment(dateTime).toDate() if dateTime?
+      timestamp = moment("#{dateTime}Z").toDate() if dateTime?
       details = rawActivity?['EventShortText']
       if details? and location? and timestamp?
         activity = {timestamp, location, details}
@@ -48,7 +48,7 @@ class LasershipClient extends ShipperClient
 
   getEta: (shipment) ->
     return unless shipment?['EstimatedDeliveryDate']?
-    moment(shipment['EstimatedDeliveryDate'], 'YYYY-MM-DD').toDate()
+    moment("#{shipment['EstimatedDeliveryDate']}T00:00:00Z").toDate()
 
   getService: (shipment) ->
 

--- a/src/ontrac.coffee
+++ b/src/ontrac.coffee
@@ -1,5 +1,5 @@
 {load} = require 'cheerio'
-moment = require 'moment'
+moment = require 'moment-timezone'
 async = require 'async'
 request = require 'request'
 {titleCase, upperCaseFirst, lowerCase} = require 'change-case'

--- a/src/ontrac.coffee
+++ b/src/ontrac.coffee
@@ -35,7 +35,7 @@ class OnTracClient extends ShipperClient
     return unless eta?
     regexMatch = eta.match('(.*) by (.*)')
     if regexMatch?.length > 1
-      eta = regexMatch[1]
+      eta = "#{regexMatch[1]} #{regexMatch[2]} +0000"
     moment(eta).toDate()
 
   getService: (shipment) ->
@@ -99,7 +99,7 @@ class OnTracClient extends ShipperClient
   presentTimestamp: (ts) ->
     return unless ts?
     ts = ts.replace(/AM$/, ' AM').replace(/PM$/, ' PM')
-    moment(ts).toDate()
+    moment("#{ts} +0000").toDate()
 
   getActivitiesAndStatus: (shipment) ->
     activities = []

--- a/src/ups.coffee
+++ b/src/ups.coffee
@@ -1,6 +1,6 @@
 {Builder, Parser} = require 'xml2js'
 request = require 'request'
-moment = require 'moment'
+moment = require 'moment-timezone'
 {titleCase, upperCaseFirst, lowerCase} = require 'change-case'
 {ShipperClient} = require './shipper'
 

--- a/src/ups.coffee
+++ b/src/ups.coffee
@@ -61,9 +61,9 @@ class UpsClient extends ShipperClient
 
   presentTimestamp: (dateString, timeString) ->
     return unless dateString?
-    formatSpec = if timeString? then 'YYYYMMDD HHmmss' else 'YYYYMMDD'
-    inputString = if timeString? then "#{dateString} #{timeString}" else dateString
-    moment(inputString, formatSpec).toDate()
+    timeString ?= '00:00:00'
+    formatSpec = 'YYYYMMDD HHmmss ZZ'
+    moment("#{dateString} #{timeString} +0000", formatSpec).toDate()
 
   presentAddress: (rawAddress) ->
     return unless rawAddress

--- a/src/upsmi.coffee
+++ b/src/upsmi.coffee
@@ -36,7 +36,7 @@ class UpsMiClient extends ShipperClient
 
   getEta: (data) ->
     eta = @extractSummaryField data, 'Projected Delivery Date'
-    formattedEta = moment(eta) if eta?
+    formattedEta = moment("#{eta} 00:00 +0000") if eta?
     if formattedEta.isValid() then formattedEta.toDate() else undefined
 
   getService: ->
@@ -56,6 +56,12 @@ class UpsMiClient extends ShipperClient
       break if status?
     parseInt(status, 10) if status?
 
+  extractTimestamp: (tsString) ->
+    if tsString.match ':'
+      return moment("#{tsString} +0000").toDate()
+    else
+      return moment("#{tsString} 00:00 +0000").toDate()
+
   extractActivities: ($, table) ->
     activities = []
     $(table).children('tr').each (rindex, row) =>
@@ -64,7 +70,7 @@ class UpsMiClient extends ShipperClient
       $(row).children('td').each (cindex, col) =>
         value = $(col)?.text()?.trim()
         switch cindex
-          when 0 then timestamp = moment(value).toDate()
+          when 0 then timestamp = @extractTimestamp value
           when 1 then details = value
           when 2 then location = @presentLocationString value
       if details? and location? and timestamp?

--- a/src/upsmi.coffee
+++ b/src/upsmi.coffee
@@ -1,5 +1,5 @@
 {load} = require 'cheerio'
-moment = require 'moment'
+moment = require 'moment-timezone'
 request = require 'request'
 {titleCase, upperCaseFirst, lowerCase} = require 'change-case'
 {ShipperClient} = require './shipper'

--- a/src/usps.coffee
+++ b/src/usps.coffee
@@ -1,6 +1,6 @@
 {Builder, Parser} = require 'xml2js'
 request = require 'request'
-moment = require 'moment'
+moment = require 'moment-timezone'
 {titleCase, upperCaseFirst, lowerCase} = require 'change-case'
 {ShipperClient} = require './shipper'
 

--- a/src/usps.coffee
+++ b/src/usps.coffee
@@ -40,8 +40,9 @@ class UspsClient extends ShipperClient
   getWeight: (shipment) ->
 
   presentTimestamp: (dateString, timeString) ->
-    tsString = if dateString? and timeString? then "#{dateString} #{timeString}" else dateString
-    moment(tsString).toDate() if tsString?
+    return unless dateString?
+    timeString = if timeString?.length then timeString else '12:00 am'
+    moment("#{dateString} #{timeString} +0000").toDate()
 
   presentStatus: (status) ->
     return ShipperClient.STATUS_TYPES.UNKNOWN

--- a/test/a1.coffee
+++ b/test/a1.coffee
@@ -31,7 +31,7 @@ describe "a1 client", ->
         expect(_package.destination).to.equal 'Chicago, IL 60607'
 
       it "has an eta of July 13th", ->
-        expect(_package.eta).to.deep.equal new Date '2015-07-13T05:00:00.000Z'
+        expect(_package.eta).to.deep.equal new Date '2015-07-13T00:00:00.000Z'
 
       it "has 1 activity", ->
         expect(_package.activities).to.have.length 1
@@ -60,7 +60,7 @@ describe "a1 client", ->
         expect(_package.destination).to.equal 'Chicago, IL 60634'
 
       it "has an eta of October 7th", ->
-        expect(_package.eta).to.deep.equal new Date '2013-10-07T05:00:00.000Z'
+        expect(_package.eta).to.deep.equal new Date '2013-10-07T00:00:00.000Z'
 
       it "has 5 activities", ->
         expect(_package.activities).to.have.length 5

--- a/test/amazon.coffee
+++ b/test/amazon.coffee
@@ -47,5 +47,5 @@ describe "amazon client", ->
         expect(_package.status).to.equal ShipperClient.STATUS_TYPES.EN_ROUTE
 
       it "has an eta of August 6th 8pm", ->
-        expect(_package.eta).to.deep.equal new Date 'Aug 6 2014 20:00:00'
+        expect(_package.eta).to.deep.equal new Date '2014-08-06T20:00:00Z'
 

--- a/test/amazon.coffee
+++ b/test/amazon.coffee
@@ -1,7 +1,7 @@
 fs = require 'fs'
 async = require 'async'
 assert = require 'assert'
-moment = require 'moment'
+moment = require 'moment-timezone'
 should = require('chai').should()
 expect = require('chai').expect
 bond = require 'bondjs'

--- a/test/dhl.coffee
+++ b/test/dhl.coffee
@@ -69,11 +69,11 @@ describe "dhl client", ->
         act = _package.activities[0]
         expect(act.location).to.equal 'Boston, MA'
         expect(act.details).to.equal 'Shipment delivered'
-        expect(act.timestamp).to.deep.equal new Date 'Mar 14 2014 14:06:00'
+        expect(act.timestamp).to.deep.equal new Date '2014-03-14T14:06:00Z'
         act = _package.activities[14]
         expect(act.location).to.equal 'Ahmedabad, India'
         expect(act.details).to.equal 'Shipment picked up'
-        expect(act.timestamp).to.deep.equal new Date 'Mar 12 2014 16:24:00'
+        expect(act.timestamp).to.deep.equal new Date '2014-03-12T16:24:00Z'
 
     describe "in transit package", ->
 
@@ -101,8 +101,8 @@ describe "dhl client", ->
         act = _package.activities[0]
         expect(act.location).to.equal 'Kuwait, Kuwait'
         expect(act.details).to.equal 'Clearance Delay'
-        expect(act.timestamp).to.deep.equal new Date 'Mar 16 2014 14:48:00'
+        expect(act.timestamp).to.deep.equal new Date '2014-03-16T14:48:00Z'
         act = _package.activities[13]
         expect(act.location).to.equal 'Dayton, OH'
         expect(act.details).to.equal 'Shipment picked up'
-        expect(act.timestamp).to.deep.equal new Date 'Mar 13 2014 15:05:00'
+        expect(act.timestamp).to.deep.equal new Date '2014-03-13T15:05:00Z'

--- a/test/guessCarrier.coffee
+++ b/test/guessCarrier.coffee
@@ -122,6 +122,8 @@ describe 'carrier guesser', ->
     it 'detects a lasership tracking number with lower case prefix', ->
       expect(guessCarrier 'le17119906').to.include 'lasership'
 
+    it 'detects a lasership tracking number beginning with 1LS', ->
+      expect(guessCarrier '1LS72264319420039910').to.include 'lasership'
 
   describe 'for ontrac', ->
 

--- a/test/lasership.coffee
+++ b/test/lasership.coffee
@@ -74,3 +74,36 @@ describe "lasership client", ->
 
       it "has a weight of 2.282 lbs", ->
         expect(_package.weight).to.equal "1.31 LBS"
+
+
+    describe "en-route package", ->
+      before (done) ->
+        fs.readFile 'test/stub_data/lasership_enroute.json', 'utf8', (err, doc) ->
+          _lsClient.presentResponse doc, 'trk', (err, resp) ->
+            should.not.exist(err)
+            _package = resp
+            done()
+
+      it "has a status of en-route", ->
+        expect(_package.status).to.equal ShipperClient.STATUS_TYPES.EN_ROUTE
+
+      it "has a destination of Jacksonville", ->
+        expect(_package.destination).to.equal "Jacksonville, FL 32216-4702"
+
+      it "has a weight of 5.25 lbs", ->
+        expect(_package.weight).to.equal "5.25 lbs"
+
+      it "has an eta of Sep 23rd, 2015", ->
+        expect(_package.eta).to.deep.equal moment('2015-09-23T00:00:00Z').toDate()
+
+      it "has two activities with timestamp, location and details", ->
+        expect(_package.activities).to.have.length 2
+        act = _package.activities[0]
+        expect(act.timestamp).to.deep.equal moment('2015-09-20T14:42:14Z').toDate()
+        expect(act.location).to.equal 'Groveport, OH 43125'
+        expect(act.details).to.equal 'Origin Scan'
+        act = _package.activities[1]
+        expect(act.timestamp).to.deep.equal moment('2015-09-20T00:07:51Z').toDate()
+        expect(act.location).to.equal 'US'
+        expect(act.details).to.equal 'Ship Request Received'
+

--- a/test/lasership.coffee
+++ b/test/lasership.coffee
@@ -3,6 +3,7 @@ assert = require 'assert'
 should = require('chai').should()
 expect = require('chai').expect
 bond = require 'bondjs'
+moment = require 'moment-timezone'
 {LasershipClient} = require '../lib/lasership'
 {ShipperClient} = require '../lib/shipper'
 
@@ -49,11 +50,11 @@ describe "lasership client", ->
       it "has four activities with timestamp, location and details", ->
         expect(_package.activities).to.have.length 4
         act = _package.activities[0]
-        expect(act.timestamp).to.deep.equal new Date '2014-03-04T16:45:34'
+        expect(act.timestamp).to.deep.equal new Date '2014-03-04T10:45:34Z'
         expect(act.location).to.equal 'New York, NY 10001-2828'
         expect(act.details).to.equal 'Delivered'
         act = _package.activities[3]
-        expect(act.timestamp).to.deep.equal new Date '2014-03-04T04:36:12'
+        expect(act.timestamp).to.deep.equal new Date '2014-03-03T22:36:12Z'
         expect(act.location).to.equal 'US'
         expect(act.details).to.equal 'Ship Request Received'
 

--- a/test/ontrac.coffee
+++ b/test/ontrac.coffee
@@ -4,6 +4,7 @@ assert = require 'assert'
 should = require('chai').should()
 expect = require('chai').expect
 bond = require 'bondjs'
+moment = require 'moment-timezone'
 {OnTracClient} = require '../lib/ontrac'
 {ShipperClient} = require '../lib/shipper'
 
@@ -41,7 +42,7 @@ describe "on trac client", ->
         expect(_package.destination).to.equal 'Fountain Valley, CA'
 
       it "has an eta of March 17th, 2014", ->
-        expect(_package.eta).to.deep.equal new Date '3/17/2014'
+        expect(_package.eta).to.deep.equal moment('2014-03-17T20:00:00.000Z').toDate()
 
       it "has a service of Caltrac", ->
         expect(_package.service).to.equal "Caltrac"
@@ -49,7 +50,7 @@ describe "on trac client", ->
       it "has a weight of 2 lbs.", ->
         expect(_package.weight).to.equal "2 lbs."
 
-      it "has 15 activities with timestamp, location and details", ->
+      it "has 2 activities with timestamp, location and details", ->
         expect(_package.activities).to.have.length 2
-        verifyActivity(_package.activities[0], 'Mar 15 2014 4:30 am', 'Orange, CA', 'Package received at facility')
-        verifyActivity(_package.activities[1], 'Mar 14 2014 5:30 pm', 'Stockton, CA', 'Data entry')
+        verifyActivity(_package.activities[0], moment('2014-03-15T04:30:00.000Z').toDate(), 'Orange, CA', 'Package received at facility')
+        verifyActivity(_package.activities[1], moment('2014-03-14T17:30:00.000Z').toDate(), 'Stockton, CA', 'Data entry')

--- a/test/stub_data/lasership_enroute.json
+++ b/test/stub_data/lasership_enroute.json
@@ -1,0 +1,59 @@
+{
+  "OrderNumber": "27315538",
+  "ReceivedOn": "2015-09-20T04:05:31",
+  "UTCReceivedOn": "2015-09-20T04:05:31",
+  "EstimatedDeliveryDate": "2015-09-23",
+  "Origin": {
+    "City": "LOCKBOURNE",
+    "State": "OH",
+    "PostalCode": "43194-9304",
+    "Country": "US"
+  },
+  "Destination": {
+    "City": "JACKSONVILLE",
+    "State": "FL",
+    "PostalCode": "32216-4702",
+    "Country": "US"
+  },
+  "Pieces": [
+    {
+    "TrackingNumber": "1LS72264319420039910",
+    "Weight": "5.25",
+    "WeightUnit": "lbs"
+  }
+  ],
+  "Events": [
+    {
+    "DateTime": "2015-09-20T14:42:14",
+    "UTCDateTime": "2015-09-20T18:42:14",
+    "City": "GROVEPORT",
+    "State": "OH",
+    "PostalCode": "43125",
+    "Country": "US",
+    "EventType": "Received",
+    "EventLabel": "Origin Scan",
+    "EventShortText": "Origin Scan",
+    "EventLongText": "LaserShip Origin Scan",
+    "Signature": "",
+    "Signature2": "",
+    "Location": "",
+    "Reason": ""
+  },
+  {
+    "DateTime": "2015-09-20T00:07:51",
+    "UTCDateTime": "2015-09-20T04:07:51",
+    "City": "",
+    "State": "",
+    "PostalCode": "",
+    "Country": "US",
+    "EventType": "OrderCreated",
+    "EventLabel": "Order Received",
+    "EventShortText": "Ship Request Received",
+    "EventLongText": "Shipment information received by LaserShip",
+    "Signature": "",
+    "Signature2": "",
+    "Location": "",
+    "Reason": ""
+  }
+  ]
+}

--- a/test/ups.coffee
+++ b/test/ups.coffee
@@ -3,6 +3,7 @@ assert = require 'assert'
 should = require('chai').should()
 expect = require('chai').expect
 bond = require 'bondjs'
+moment = require 'moment-timezone'
 {UpsClient} = require '../lib/ups'
 {ShipperClient} = require '../lib/shipper'
 {Builder, Parser} = require 'xml2js'
@@ -302,11 +303,11 @@ describe "ups client", ->
 
     it "uses only the date string if time string isn't specified", ->
       ts = _upsClient.presentTimestamp '20140704'
-      expect(ts).to.deep.equal new Date 'Jul 04 2014 00:00:00'
+      expect(ts).to.deep.equal moment('2014-07-04T00:00:00.000Z').toDate()
 
     it "uses the date and time strings when both are available", ->
       ts = _upsClient.presentTimestamp '20140704', '142305'
-      expect(ts).to.deep.equal new Date 'Jul 04 2014 14:23:05'
+      expect(ts).to.deep.equal moment('2014-07-04T14:23:05.000Z').toDate()
 
   describe "presentAddress", ->
     _presentLocationSpy = null
@@ -414,10 +415,10 @@ describe "ups client", ->
         expect(_package.activities).to.have.length 2
         act1 = _package.activities[0]
         act2 = _package.activities[1]
-        expect(act1.timestamp).to.deep.equal new Date 'Jun 10 2010 12:00:00'
+        expect(act1.timestamp).to.deep.equal moment('2010-06-10T12:00:00.000Z').toDate()
         expect(act1.location).to.equal 'Anytown, GA 30340'
         expect(act1.details).to.equal 'Delivered'
-        expect(act2.timestamp).to.deep.equal new Date 'Jun 8 2010 12:00:00'
+        expect(act2.timestamp).to.deep.equal moment('2010-06-08T12:00:00.000Z').toDate()
         expect(act2.location).to.equal 'US'
         expect(act2.details).to.equal 'Billing information received. shipment date pending.'
 
@@ -444,7 +445,7 @@ describe "ups client", ->
       it "has one activity with timestamp, location and details", ->
         expect(_package.activities).to.have.length 1
         act = _package.activities[0]
-        expect(act.timestamp).to.deep.equal new Date 'May 05 2010 01:00:00'
+        expect(act.timestamp).to.deep.equal moment('2010-05-05T01:00:00.000Z').toDate()
         expect(act.location).to.equal 'Grand Junction Air s, CO'
         expect(act.details).to.equal 'Origin scan'
 
@@ -471,11 +472,12 @@ describe "ups client", ->
       it "has 6 activities with timestamp, location and details", ->
         expect(_package.activities).to.have.length 6
         act = _package.activities[0]
-        expect(act.timestamp).to.deep.equal new Date 'Aug 30 1998 10:39:00'
+        expect(act.timestamp).to.deep.equal moment('1998-08-30T10:39:00.000Z').toDate()
+        new Date 'Aug 30 1998 10:39:00'
         expect(act.location).to.equal 'Bonn, DE'
         expect(act.details).to.equal 'Ups internal activity code'
         act = _package.activities[1]
-        expect(act.timestamp).to.deep.equal new Date 'Aug 30 2010 10:32:00'
+        expect(act.timestamp).to.deep.equal moment('2010-08-30T10:32:00.000Z').toDate()
         expect(act.location).to.equal 'Bonn, DE'
         expect(act.details).to.equal 'Adverse weather conditions caused this delay'
 
@@ -494,7 +496,7 @@ describe "ups client", ->
         expect(_package.destination).to.equal 'Chicago, IL 60607'
 
       it "has an eta of", ->
-        expect(_package.eta).to.deep.equal new Date '2014-10-24T05:00:00.000Z'
+        expect(_package.eta).to.deep.equal moment('2014-10-24T00:00:00.000Z').toDate()
 
     describe "2nd tracking number", ->
       before (done) ->

--- a/test/upsmi.coffee
+++ b/test/upsmi.coffee
@@ -4,6 +4,7 @@ assert = require 'assert'
 should = require('chai').should()
 expect = require('chai').expect
 bond = require 'bondjs'
+moment = require 'moment-timezone'
 {UpsMiClient} = require '../lib/upsmi'
 {ShipperClient} = require '../lib/shipper'
 
@@ -26,7 +27,7 @@ describe "ups mi client", ->
             done()
 
       verifyActivity = (act, ts, loc, details) ->
-        expect(act.timestamp).to.deep.equal new Date ts
+        expect(act.timestamp.getTime()).to.equal ts
         expect(act.location).to.equal loc
         expect(act.details).to.equal details
 
@@ -34,7 +35,7 @@ describe "ups mi client", ->
         expect(_package.status).to.equal ShipperClient.STATUS_TYPES.DELIVERED
 
       it "has an eta of Mar 25 2014", ->
-        expect(_package.eta).to.deep.equal new Date '3/25/2014'
+        expect(_package.eta.getTime()).to.equal 1395705600000
 
       it "has a weight of 0.3050 lbs.", ->
         expect(_package.weight).to.equal "0.3050 lbs."
@@ -44,8 +45,8 @@ describe "ups mi client", ->
 
       it "has 11 activities with timestamp, location and details", ->
         expect(_package.activities).to.have.length 11
-        verifyActivity(_package.activities[0], 'Mar 25 2014 6:07 pm', 'Brooklyn, NY', 'Package delivered by local post office')
-        verifyActivity(_package.activities[10], 'Mar 20 2014', 'Kansas City, MO', 'Package received for processing')
+        verifyActivity(_package.activities[0], 1395770820000, 'Brooklyn, NY', 'Package delivered by local post office')
+        verifyActivity(_package.activities[10], 1395273600000, 'Kansas City, MO', 'Package received for processing')
 
     describe "about to ship package", ->
 
@@ -57,7 +58,7 @@ describe "ups mi client", ->
             done()
 
       verifyActivity = (act, ts, loc, details) ->
-        expect(act.timestamp).to.deep.equal new Date ts
+        expect(act.timestamp.getTime()).to.equal ts
         expect(act.location).to.equal loc
         expect(act.details).to.equal details
 
@@ -75,5 +76,5 @@ describe "ups mi client", ->
 
       it "has 1 activity with timestamp, location and details", ->
         expect(_package.activities).to.have.length 1
-        verifyActivity(_package.activities[0], 'Mar 24 2014', '', 'Shipment information received')
+        verifyActivity(_package.activities[0], 1395619200000, '', 'Shipment information received')
 

--- a/test/usps.coffee
+++ b/test/usps.coffee
@@ -3,6 +3,7 @@ assert = require 'assert'
 should = require('chai').should()
 expect = require('chai').expect
 bond = require 'bondjs'
+moment = require 'moment-timezone'
 {UspsClient} = require '../lib/usps'
 {ShipperClient} = require '../lib/shipper'
 {Builder, Parser} = require 'xml2js'
@@ -72,7 +73,7 @@ describe "usps client", ->
 
       it "has only one activity", ->
         expect(_package.activities).to.have.length 1
-        expect(_package.activities[0].timestamp).to.deep.equal new Date 'Feb 28 2014 00:00:00'
+        expect(_package.activities[0].timestamp.getTime()).to.equal 1393545600000
         expect(_package.activities[0].location).to.equal ''
         expect(_package.activities[0].details).to.equal 'Electronic Shipping Info Received'
 
@@ -99,10 +100,10 @@ describe "usps client", ->
         act9 = _package.activities[8]
         expect(act1.details).to.equal 'Delivered'
         expect(act1.location).to.equal 'Chicago, IL 60610'
-        expect(act1.timestamp).to.deep.equal new Date 'Feb 13, 2014 12:24 pm'
+        expect(act1.timestamp).to.deep.equal moment('Feb 13, 2014 12:24 pm +0000').toDate()
         expect(act9.details).to.equal 'Acceptance'
         expect(act9.location).to.equal 'Pomona, CA 91768'
-        expect(act9.timestamp).to.deep.equal new Date 'Feb 10, 2014 11:31 am'
+        expect(act9.timestamp).to.deep.equal moment('Feb 10, 2014 11:31 am +0000').toDate()
 
     describe "out-for-delivery package", ->
       before (done) ->
@@ -127,8 +128,8 @@ describe "usps client", ->
         act5 = _package.activities[4]
         expect(act1.details).to.equal 'Out for Delivery'
         expect(act1.location).to.equal 'New York, NY 10022'
-        expect(act1.timestamp).to.deep.equal new Date 'Mar 02, 2014 08:09 am'
+        expect(act1.timestamp).to.deep.equal moment('Mar 02, 2014 08:09 am +0000').toDate()
         expect(act5.details).to.equal 'Electronic Shipping Info Received'
         expect(act5.location).to.equal ''
-        expect(act5.timestamp).to.deep.equal new Date 'Mar 1, 2014'
+        expect(act5.timestamp).to.deep.equal moment('Mar 1, 2014 00:00:00 +0000').toDate()
 


### PR DESCRIPTION
Most carriers don't provide a timezone for their event and ETA timestamps.  So, we must interpret them as "local time", which is resolvable by Google's timezone api, using a geolocated lat/lng for each tracking event.  Unfortunately, this support can't be optimally built into this API because it'll require numerous calls to Google's APIs.  Clients may want to cache those responses instead of hitting Google every single time, incurring costs.  Therefore, timestamps from the carrier are always interpreted as UTC timestamps, and it is up to the client to override the timezone to the location specific one.