### PR TITLE
Update USPS to prefer PredictedDeliveryDate for ETA

### DIFF
--- a/src/usps.coffee
+++ b/src/usps.coffee
@@ -31,8 +31,8 @@ class UspsClient extends ShipperClient
 
   getEta: (shipment) ->
     rawEta =
-      shipment['ExpectedDeliveryDate']?[0] or
-      shipment['PredictedDeliveryDate']?[0]
+      shipment['PredictedDeliveryDate']?[0] or
+      shipment['ExpectedDeliveryDate']?[0]
     moment("#{rawEta} 00:00:00Z").toDate() if rawEta?
 
   getService: (shipment) ->


### PR DESCRIPTION
From my testing, when USPS returns both an ExpectedDeliveryDate and a PredictedDeliveryDate, the PredictedDeliveryDate is far more accurate. I have updated the USPS client to prefer that as the ETA.