### PR TITLE
render a datetime in addition to timestamp for carriers that provide timezone in shipment activites

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,19 @@ Example response returned:
         {
             "location": "Memphis, TN 38118",
             "timestamp": "2014-02-16T22:19:00.000Z",
+            "datetime": "2014-02-16T17:19:00",
             "details": "Departed FedEx location"
         },
         {
             "location": "East Hanover, NJ 07936",
             "timestamp": "2014-02-15T23:57:00.000Z",
+            "datetime": "2014-02-15T18:57:00",
             "details": "Left FedEx origin facility"
         },
         {
             "location": "East Hanover, NJ 07936",
             "timestamp": "2014-02-15T15:57:00.000Z",
+            "datetime": "2014-02-15T10:57:00",
             "details": "Picked up"
         }
     ],
@@ -150,6 +153,8 @@ Example response returned:
     }
 }
 ```
+#### A Note on `timestamp` and `datetime`
+There are two types of shipping carriers - one that provide a date and time in their shipping activities that represents the local time at the location indicated. And another that provide a timestamp, which includes a UTC offset. In the first case, since a timezone is not known, shipit just assumes UTC, and returns a `timestamp` attribute in the `activity` objects. In the second case, shipit returns a `timestamp` attribute which has a UTC offset embedded in it, and also a `datetime` attribute which represents the local time.
 
 ### Using the Carrier Guesser
 There's usually only one carrier that matches a tracking number (UPS is the only carrier that uses '1Z' prefix for its tracking numbers), but there are several cases, where there are multiple matches.  For example, FedEx uses a service called SmartPost, where it relies on USPS to deliver the package at the last mile.  In such cases, FedEx provides tracking through most of the package's journey, and then USPS either takes over, or provides duplicate tracking in the last leg.  The tracking number used is the same between the two carriers.  Similar situation with UPS Mail Innovations as well.  Therefore, the `guessCarrier()` function returns an array, and we leave it up to the user to decide manually or through other automated means which carrier is the real one or provides more accurate tracking.

--- a/src/a1.coffee
+++ b/src/a1.coffee
@@ -54,14 +54,18 @@ class A1Client extends ShipperClient
   getActivitiesAndStatus: (shipment) ->
     activities = []
     status = null
-    for rawActivity in shipment['TrackingEventHistory']?[0]?['TrackingEventDetail'] or []
+    rawActivities = shipment['TrackingEventHistory']?[0]?['TrackingEventDetail']
+    for rawActivity in rawActivities or []
       location = @presentAddress rawActivity?['EventLocation']?[0]
-      timestamp = moment("#{rawActivity?['EventDateTime'][0][..18]}Z")
-        .toDate() if rawActivity?['EventDateTime']?[0]?
+      raw_timestamp = rawActivity?['EventDateTime'][0]
+      if raw_timestamp?
+        event_time = moment(raw_timestamp)
+        timestamp = event_time.toDate()
+        datetime = raw_timestamp[..18]
       details = rawActivity?['EventCodeDesc']?[0]
 
       if details? and timestamp?
-        activity = {timestamp, location, details}
+        activity = {timestamp, datetime, location, details}
         activities.push activity
     activities: activities, status: @getStatus shipment
 

--- a/src/fedex.coffee
+++ b/src/fedex.coffee
@@ -101,11 +101,14 @@ class FedexClient extends ShipperClient
     status = null
     for rawActivity in shipment['Events'] or []
       location = @presentAddress rawActivity['Address']?[0]
-      timestamp = moment("#{rawActivity['Timestamp'][0][..18]}Z")
-        .toDate() if rawActivity['Timestamp']?[0]?
+      raw_timestamp = rawActivity['Timestamp']?[0]
+      if raw_timestamp?
+        event_time = moment(raw_timestamp)
+        timestamp = event_time.toDate()
+        datetime = raw_timestamp[..18]
       details = rawActivity['EventDescription']?[0]
       if details? and timestamp?
-        activity = {timestamp, location, details}
+        activity = {timestamp, datetime, location, details}
         activities.push activity
     activities: activities, status: @getStatus shipment
 

--- a/test/a1.coffee
+++ b/test/a1.coffee
@@ -38,7 +38,8 @@ describe "a1 client", ->
 
       it "has first activity with timestamp, location and details", ->
         act = _package.activities[0]
-        expect(act.timestamp).to.deep.equal new Date 'Jul 10 2015 05:10:00'
+        expect(act.timestamp).to.deep.equal new Date '2015-07-10T15:10:00.000Z'
+        expect(act.datetime).to.equal '2015-07-10T10:10:00'
         expect(act.details).to.equal 'Shipment has left seller facility and is in transit'
         expect(act.location).to.equal 'Whitestown, IN 46075'
 
@@ -67,7 +68,8 @@ describe "a1 client", ->
 
       it "has first activity with timestamp, location and details", ->
         act = _package.activities[0]
-        expect(act.timestamp).to.deep.equal new Date 'Oct 08 2013 08:29:00'
+        expect(act.timestamp).to.deep.equal new Date '2013-10-08T18:29:00.000Z'
+        expect(act.datetime).to.equal '2013-10-08T13:29:00'
         expect(act.details).to.equal 'Delivered'
         expect(act.location).to.equal 'Chicago, IL 60634'
 

--- a/test/fedex.coffee
+++ b/test/fedex.coffee
@@ -151,13 +151,14 @@ describe "fedex client", ->
 
       it "has first activity with timestamp, location and details", ->
         act = _package.activities[0]
-        expect(act.timestamp).to.deep.equal new Date '2014-02-17T09:05:00.000Z'
+        expect(act.timestamp).to.deep.equal new Date '2014-02-17T14:05:00.000Z'
+        expect(act.datetime).to.equal '2014-02-17T09:05:00'
         expect(act.details).to.equal 'Delivered'
         expect(act.location).to.equal 'MD 21133'
 
       it "has last activity with timestamp, location and details", ->
         act = _package.activities[6]
-        expect(act.timestamp).to.deep.equal new Date '2014-02-15T10:57:00.000Z'
+        expect(act.timestamp).to.deep.equal new Date '2014-02-15T15:57:00.000Z'
         expect(act.details).to.equal 'Picked up'
         expect(act.location).to.equal 'East Hanover, NJ 07936'
 


### PR DESCRIPTION
Most shipping carriers have activities with time data along with location and a description of the event, like this:
```xml
<Timestamp>2016-04-30T11:52:56-04:00</Timestamp>
    <EventDescription>Delivered</EventDescription>
    <StatusExceptionDescription>
        Left at back door. Signature Service not requested.
    </StatusExceptionDescription>
    <Address>
        <City>Aiken</City>
        <StateOrProvinceCode>SC</StateOrProvinceCode>
        <PostalCode>29805</PostalCode>
        <CountryCode>US</CountryCode>
    </Address>
```

But the time information is sometimes a `timestamp`, and sometimes only a `datetime`.  The distinction between the two is that a timestamp contains timezone information (such as in the fedex example above, in the form of a UTC offset `-04:00`).  The only two carriers that provide a timezone-rich timestamp are FedEx and A1 International.  This PR updates the implementation for those two carriers to return both a timestamp and a datetime field in all the activities of a shipment.

Here's what the output for a fedex shipment will now look like (notice the `datetime` field which represents the local time at the location specified in the activity):
```json
{
  "eta": "2016-05-10T23:59:59.000Z",
  "service": "FedEx Home Delivery",
  "weight": "2.9 LB",
  "destination": "Ottumwa, IA",
  "activities": [
    {
      "timestamp": "2016-05-07T11:00:00.000Z",
      "datetime": "2016-05-07T06:00:00",
      "location": "Ottumwa, IA 52501",
      "details": "On FedEx vehicle for delivery"
    },
    {
      "timestamp": "2016-05-07T09:52:04.000Z",
      "datetime": "2016-05-07T04:52:04",
      "location": "Ottumwa, IA 52501",
      "details": "At local FedEx facility"
    },
    {
      "timestamp": "2016-05-07T07:26:02.000Z",
      "datetime": "2016-05-07T02:26:02",
      "location": "Rock Island, IL 61201",
      "details": "Departed FedEx location"
    },
    {
      "timestamp": "2016-05-07T04:48:00.000Z",
      "datetime": "2016-05-06T23:48:00",
      "location": "Rock Island, IL 61201",
      "details": "Arrived at FedEx location"
    },
    {
      "timestamp": "2016-05-07T00:58:08.000Z",
      "datetime": "2016-05-06T19:58:08",
      "location": "Carol Stream, IL 60188",
      "details": "Left FedEx origin facility"
    },
    {
      "timestamp": "2016-05-06T23:05:00.000Z",
      "datetime": "2016-05-06T18:05:00",
      "location": "Carol Stream, IL 60188",
      "details": "Arrived at FedEx location"
    },
    {
      "timestamp": "2016-05-06T21:29:00.000Z",
      "datetime": "2016-05-06T16:29:00",
      "location": "Carol Stream, IL 60188",
      "details": "Picked up"
    },
    {
      "timestamp": "2016-05-06T20:51:00.000Z",
      "datetime": "2016-05-06T15:51:00",
      "location": "US 60532",
      "details": "Shipment information sent to FedEx"
    }
  ],
  "status": 3,
  "request": {
    "trackingNumber": "783008979965"
  }
}
```